### PR TITLE
Explicitly remove reminders from synced events

### DIFF
--- a/CalendarSync.gs
+++ b/CalendarSync.gs
@@ -106,6 +106,7 @@ function createWorkEvent(workCalendar, workEventData) {
   newWorkEvent.setColor(workEventData.color);
   newWorkEvent.setDescription(workEventData.description);
   newWorkEvent.setVisibility(workEventData.visibility);
+  newWorkEvent.removeAllReminders();
 }
 
 // Check if the current work event differs from the new event data


### PR DESCRIPTION
If one needs a reminder, odds are one probably has one set on their personal event; no need to have a reminder on the work calendar as well.

I tested this with my personal calendar.