### PR TITLE
Add flag to ignore RSVP status for own events

### DIFF
--- a/CalendarSync.gs
+++ b/CalendarSync.gs
@@ -16,6 +16,12 @@ const SCRIPT_PREFIX = "Created by Script: ";
 // Number of months of future events to sync
 const LOOKAHEAD_PERIOD_MONTHS = 3;
 
+/**
+  Whether the RSVP status of events created by one of
+  your accounts (myEmails) should be ignored.
+ */
+const IGNORE_STATUS_FOR_OWN_EVENTS = true;
+
 // Runs every time an event is updated in the personal calendar
 function onPersonalCalendarUpdate() {
   const calendar = CalendarApp.getCalendarById(PERSONAL_CALENDAR_ID);
@@ -72,6 +78,9 @@ function hasAccepted(event) {
   const myStatus = event.getMyStatus();
   const creatorEmail = event.getCreators()[0];
   if (myEmails.indexOf(creatorEmail) != -1) {
+    if (IGNORE_STATUS_FOR_OWN_EVENTS) {
+      return true;
+    }
 
     return myStatus === CalendarApp.GuestStatus.YES || 
            myStatus === CalendarApp.GuestStatus.MAYBE || 


### PR DESCRIPTION
I haven't been able to pinpoint the core reason, but I've observed that for events created by me sometimes `myStatus` is `null` and others it's `CalendarApp.GuestStatus.OWNER`. The latter causes the checks again YES/MAYBE/null to fail.

It's possible that folks have use cases where they don't want to sync events that they created but haven't explicitly RSVPed to (e.g. maybe one created an event for one's partner's appointment that they themselves are not attending), so I added this as a flag to allow customization.